### PR TITLE
Refresh API documentation

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,603 +1,594 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>TheirStory API Guide</title>
-    <style>
-        body {
-            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
-            line-height: 1.6;
-            color: #333;
-            max-width: 1000px;
-            margin: 0 auto;
-            padding: 20px;
-        }
-        h1 {
-            color: #2c3e50;
-            border-bottom: 2px solid #3498db;
-            padding-bottom: 10px;
-        }
-        h2 {
-            color: #2980b9;
-            margin-top: 30px;
-        }
-        h3 {
-            color: #3498db;
-            margin-top: 25px;
-        }
-        code {
-            font-family: monospace;
-            background-color: #f8f8f8;
-            padding: 2px 4px;
-            border-radius: 3px;
-            font-size: 90%;
-        }
-        pre {
-            background-color: #f8f8f8;
-            padding: 15px;
-            border-radius: 5px;
-            overflow-x: auto;
-            border: 1px solid #ddd;
-        }
-        .endpoint-divider {
-            border-top: 1px solid #eee;
-            margin: 40px 0;
-        }
-        .index-container {
-            background-color: #f8f8f8;
-            padding: 20px;
-            border-radius: 5px;
-            margin-bottom: 30px;
-            border-left: 5px solid #3498db;
-        }
-        .index-container ul {
-            list-style-type: none;
-            padding-left: 10px;
-        }
-        .index-container li {
-            margin-bottom: 8px;
-        }
-        .index-container a {
-            color: #3498db;
-            text-decoration: none;
-        }
-        .index-container a:hover {
-            text-decoration: underline;
-        }
-        .param-table {
-            border-collapse: collapse;
-            width: 100%;
-            margin: 20px 0;
-        }
-        .param-table th, .param-table td {
-            border: 1px solid #ddd;
-            padding: 8px 12px;
-            text-align: left;
-        }
-        .param-table th {
-            background-color: #f2f2f2;
-        }
-        .param-table tr:nth-child(even) {
-            background-color: #f9f9f9;
-        }
-        .endpoint-url {
-            display: flex;
-            align-items: center;
-            margin: 10px 0;
-            background-color: #f1f9ff;
-            padding: 8px 12px;
-            border-radius: 4px;
-            border-left: 4px solid #3498db;
-        }
-        .endpoint-url code {
-            flex-grow: 1;
-            background: none;
-            padding: 0;
-        }
-        .copy-btn {
-            background-color: #f1f9ff;
-            border: none;
-            cursor: pointer;
-            padding: 4px 8px;
-            color: #3498db;
-            font-size: 16px;
-            margin-left: 10px;
-            border-radius: 4px;
-            transition: background-color 0.2s;
-        }
-        .copy-btn:hover {
-            background-color: #e1f0fe;
-        }
-        .http-method {
-            font-weight: bold;
-            color: #27ae60;
-            margin-right: 10px;
-        }
-        .response-section {
-            margin-top: 20px;
-        }
-        .field-list {
-            margin-left: 20px;
-        }
-        .field-list li {
-            margin-bottom: 5px;
-        }
-    </style>
-    <script>
-        function copyToClipboard(text) {
-            navigator.clipboard.writeText(text)
-                .then(() => {
-                    const button = event.currentTarget;
-                    const originalHTML = button.innerHTML;
-                    button.innerHTML = `
-                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="green" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                            <polyline points="20 6 9 17 4 12"></polyline>
-                        </svg>`;
-                    setTimeout(() => {
-                        button.innerHTML = originalHTML;
-                    }, 1500);
-                })
-                .catch(err => {
-                    console.error('Failed to copy text: ', err);
-                    alert('Failed to copy to clipboard. Please try again.');
-                });
-        }
-    </script>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>TheirStory API Guide</title>
+  <style>
+    :root {
+      --bg: #ffffff;
+      --text: #1f2328;
+      --muted: #57606a;
+      --link: #0969da;
+      --border: #d0d7de;
+      --border-soft: #e5e9ed;
+      --code-bg: #f6f8fa;
+      --code-text: #1f2328;
+      --callout-bg: #fff8c5;
+      --callout-border: #d4a72c;
+      --note-bg: #ddf4ff;
+      --note-border: #0969da;
+      --warn-bg: #ffebe9;
+      --warn-border: #cf222e;
+    }
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --bg: #0d1117;
+        --text: #e6edf3;
+        --muted: #8b949e;
+        --link: #2f81f7;
+        --border: #30363d;
+        --border-soft: #21262d;
+        --code-bg: #161b22;
+        --code-text: #e6edf3;
+        --callout-bg: #2d2611;
+        --callout-border: #9e6a03;
+        --note-bg: #0c2d6b;
+        --note-border: #1f6feb;
+        --warn-bg: #3c0e10;
+        --warn-border: #f85149;
+      }
+    }
+    * { box-sizing: border-box; }
+    html { -webkit-text-size-adjust: 100%; }
+    body {
+      margin: 0;
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans", Helvetica, Arial, sans-serif;
+      font-size: 16px;
+      line-height: 1.6;
+      color: var(--text);
+      background: var(--bg);
+    }
+    .container {
+      max-width: 920px;
+      margin: 0 auto;
+      padding: 32px 24px 96px;
+    }
+    h1, h2, h3, h4, h5 {
+      line-height: 1.25;
+      margin-top: 1.8em;
+      margin-bottom: 0.6em;
+      font-weight: 600;
+    }
+    h1 {
+      font-size: 2em;
+      margin-top: 0;
+      padding-bottom: 0.3em;
+      border-bottom: 1px solid var(--border);
+    }
+    h2 {
+      font-size: 1.5em;
+      padding-bottom: 0.3em;
+      border-bottom: 1px solid var(--border-soft);
+    }
+    h3 { font-size: 1.25em; }
+    h4 { font-size: 1em; }
+    h5 { font-size: 0.95em; color: var(--muted); }
+    p { margin: 0 0 1em; }
+    a { color: var(--link); text-decoration: none; }
+    a:hover { text-decoration: underline; }
+    ul, ol { padding-left: 2em; margin: 0 0 1em; }
+    li + li { margin-top: 0.25em; }
+    code {
+      font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+      font-size: 0.875em;
+      background: var(--code-bg);
+      color: var(--code-text);
+      padding: 0.15em 0.4em;
+      border-radius: 6px;
+    }
+    pre {
+      background: var(--code-bg);
+      color: var(--code-text);
+      padding: 16px;
+      border-radius: 6px;
+      overflow: auto;
+      font-size: 0.85em;
+      line-height: 1.5;
+      margin: 0 0 1em;
+    }
+    pre code {
+      background: transparent;
+      padding: 0;
+      font-size: 1em;
+    }
+    table {
+      border-collapse: collapse;
+      width: 100%;
+      margin: 0 0 1em;
+      font-size: 0.95em;
+    }
+    th, td {
+      border: 1px solid var(--border);
+      padding: 8px 12px;
+      text-align: left;
+      vertical-align: top;
+    }
+    th {
+      background: var(--code-bg);
+      font-weight: 600;
+    }
+    blockquote {
+      margin: 0 0 1em;
+      padding: 12px 16px;
+      border-left: 4px solid var(--callout-border);
+      background: var(--callout-bg);
+      color: var(--text);
+      border-radius: 0 6px 6px 0;
+    }
+    blockquote.note {
+      border-left-color: var(--note-border);
+      background: var(--note-bg);
+    }
+    blockquote.warn {
+      border-left-color: var(--warn-border);
+      background: var(--warn-bg);
+    }
+    blockquote p:last-child { margin-bottom: 0; }
+    .endpoint {
+      font-family: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, monospace;
+      font-size: 0.95em;
+      background: var(--code-bg);
+      padding: 10px 14px;
+      border-radius: 6px;
+      border-left: 4px solid var(--link);
+      margin: 0 0 1em;
+      overflow-x: auto;
+    }
+    .endpoint .method {
+      font-weight: 700;
+      color: var(--link);
+      margin-right: 0.5em;
+    }
+    .toc {
+      background: var(--code-bg);
+      padding: 16px 24px;
+      border-radius: 6px;
+      margin: 0 0 2em;
+    }
+    .toc ul { padding-left: 1.4em; }
+    .toc > ul { padding-left: 1.2em; }
+    .toc h2 {
+      margin-top: 0;
+      border-bottom: none;
+      font-size: 1.1em;
+    }
+    hr {
+      border: 0;
+      border-top: 1px solid var(--border-soft);
+      margin: 2em 0;
+    }
+    .anchor {
+      display: block;
+      position: relative;
+      top: -20px;
+      visibility: hidden;
+    }
+  </style>
 </head>
 <body>
-    <h1>TheirStory API Guide</h1>
-    
-    <div class="index-container">
-        <h2>Contents</h2>
-        <ul>
-            <li><a href="#overview">Overview</a></li>
-            <li><a href="#api-endpoints">API Endpoints</a>
-                <ul>
-                    <li><a href="#signin">Sign In</a></li>
-                    <li><a href="#current-user">Current User Information</a></li>
-                    <li><a href="#projects">Projects</a></li>
-                    <li><a href="#organization">Organization</a></li>
-                    <li><a href="#stories">Stories</a>
-                <ul>
-                    <li><a href="#transcript-json">Get Story Transcript JSON</a></li>
-                    <li><a href="#transcript-html">Get Story Transcript HTML</a></li>
-                </ul>
-            </li>
-                    <li><a href="#groups">Groups</a></li>
-                </ul>
-            </li>
-            <li><a href="#error-handling">Error Handling</a></li>
-            <li><a href="#security">Security Considerations</a></li>
-        </ul>
-    </div>
+<div class="container">
 
-    <section id="overview">
-        <h2>Overview</h2>
-        <p>TheirStory provides a web-based interviewing and storytelling platform that helps families and organizations collect and make accessible audiovisual oral histories. This API guide details how to interact with the TheirStory API to access user information and associated features.</p>
-    </section>
+<h1>TheirStory API Guide</h1>
 
-    <div class="endpoint-divider"></div>
+<div class="toc">
+  <h2>Contents</h2>
+  <ul>
+    <li><a href="#overview">Overview</a></li>
+    <li><a href="#base-urls">Base URL</a></li>
+    <li><a href="#authentication">Authentication</a>
+      <ul>
+        <li><a href="#auth-header">Authorization header format (important)</a></li>
+        <li><a href="#token-storage">Token storage in browser clients</a></li>
+        <li><a href="#token-lifetime">Token lifetime and refresh</a></li>
+      </ul>
+    </li>
+    <li><a href="#conventions">Conventions</a>
+      <ul>
+        <li><a href="#request-format">Request and response format</a></li>
+        <li><a href="#field-naming">Field naming</a></li>
+        <li><a href="#internal-fields">Internal fields</a></li>
+        <li><a href="#pagination">Pagination</a></li>
+      </ul>
+    </li>
+    <li><a href="#api-endpoints">API endpoints</a>
+      <ul>
+        <li><a href="#signin">Sign in</a></li>
+        <li><a href="#current-user">Current user information</a></li>
+        <li><a href="#projects">Projects</a></li>
+        <li><a href="#organization">Organization</a></li>
+        <li><a href="#stories">Stories</a>
+          <ul>
+            <li><a href="#transcript-json">Get story transcript JSON</a></li>
+            <li><a href="#transcript-html">Get story transcript HTML</a></li>
+          </ul>
+        </li>
+        <li><a href="#groups">Groups</a></li>
+        <li><a href="#publishing">Publishing</a></li>
+      </ul>
+    </li>
+    <li><a href="#error-handling">Error handling</a></li>
+    <li><a href="#rate-limits">Rate limits</a></li>
+    <li><a href="#security">Security considerations</a></li>
+    <li><a href="#versioning">Versioning</a></li>
+    <li><a href="#support">Support</a></li>
+  </ul>
+</div>
 
-    <section id="api-endpoints">
-        <h2>API Endpoints</h2>
-        
-        <section id="signin">
-            <h3>Sign In</h3>
-        <p>The API uses JWT (JSON Web Tokens) for authentication. Tokens are returned in API responses and should be included in subsequent requests.</p>
-        
-        <p>Authenticates a user and returns user information along with an access token.</p>
+<h2 id="overview">Overview</h2>
 
-        <div class="endpoint-url">
-            <span class="http-method">POST</span>
-            <code>https://node.theirstory.io/signin</code>
-            <button class="copy-btn" onclick="copyToClipboard('https://node.theirstory.io/signin')">
-                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                    <path d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2"></path>
-                    <rect x="8" y="2" width="8" height="4" rx="1" ry="1"></rect>
-                </svg>
-            </button>
-        </div>
+<p>TheirStory provides a web-based interviewing and storytelling platform that helps families and organizations collect and make accessible audiovisual oral histories. This guide details how to interact with the TheirStory HTTP API to authenticate, read user and organization data, and access stories, transcripts, and published media.</p>
 
-        <h4>Request Body:</h4>
-        <p>The request should include user credentials in JSON format.</p>
-        <pre><code>{
+<p>This document covers the read API. Write operations (creating projects, uploading recordings, editing stories) are not yet publicly documented; contact us if you need them.</p>
+
+<h2 id="base-urls">Base URL</h2>
+
+<p>The API base URL is <code>https://node.theirstory.io</code>. All examples below use this base URL. The API is served over HTTPS only.</p>
+
+<h2 id="authentication">Authentication</h2>
+
+<p>The API uses JSON Web Tokens (JWTs). You obtain a token by calling <a href="#signin"><code>POST /signin</code></a> with email and password credentials, and you include the token on every subsequent request.</p>
+
+<h3 id="auth-header">Authorization header format (important)</h3>
+
+<blockquote class="warn">
+  <p><strong>The <code>Authorization</code> header on this API does not use the <code>Bearer</code> scheme.</strong> Send the raw JWT as the header value, with no <code>Bearer </code> prefix. This differs from the convention described in <a href="https://datatracker.ietf.org/doc/html/rfc6750">RFC 6750</a> and from the default behavior of most API testing tools (Postman, Insomnia, <code>curl</code> examples copied from other APIs) and many client libraries.</p>
+</blockquote>
+
+<p><strong>Correct:</strong></p>
+
+<pre><code>Authorization: eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9...</code></pre>
+
+<p><strong>Incorrect (will return 403):</strong></p>
+
+<pre><code>Authorization: Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9...</code></pre>
+
+<p>If you receive <code>403 Forbidden</code> on every call despite having a valid token, this is the first thing to check. We plan to add support for the standard <code>Bearer</code> scheme; until then, configure your tooling accordingly.</p>
+
+<p><strong>Postman:</strong> Set the Authorization type to "API Key", with the key set to <code>Authorization</code>, the value set to the raw token (not "Bearer Token"), and "Add to" set to "Header".</p>
+
+<p><strong>curl:</strong></p>
+
+<pre><code>curl -H "Authorization: $TS_TOKEN" \
+  "https://node.theirstory.io/current_user?visitorId=..."</code></pre>
+
+<h3 id="token-storage">Token storage in browser clients</h3>
+
+<p>If you are calling this API from server-side code, store the token in your server's secret store (environment variables, a secrets manager, etc.) and never send it to the browser.</p>
+
+<p>If you are calling this API directly from a browser, you have three options, all with tradeoffs:</p>
+
+<table>
+  <thead>
+    <tr>
+      <th>Option</th>
+      <th>XSS-readable?</th>
+      <th>Survives page refresh?</th>
+      <th>Notes</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>In-memory</td>
+      <td>No</td>
+      <td>No</td>
+      <td>Safest, but the user must sign in again on every reload.</td>
+    </tr>
+    <tr>
+      <td><code>sessionStorage</code></td>
+      <td>Yes</td>
+      <td>No (cleared on tab close)</td>
+      <td>Convenient; vulnerable to XSS.</td>
+    </tr>
+    <tr>
+      <td><code>localStorage</code></td>
+      <td>Yes</td>
+      <td>Yes</td>
+      <td>Most convenient; vulnerable to XSS. This is what the sample code below uses.</td>
+    </tr>
+  </tbody>
+</table>
+
+<p>The sample code below uses <code>localStorage</code> for simplicity. <strong>This is a convenience tradeoff, not a security recommendation.</strong> Any script running on your page &mdash; including third-party tags, dependencies, or extensions &mdash; can read <code>localStorage</code> and exfiltrate the token. For production browser integrations, the safest pattern is a backend-for-frontend (BFF): your server holds the TheirStory token, and your browser code authenticates against your own server with a session cookie. The browser never sees the TheirStory token.</p>
+
+<p>We are tracking work to support <code>HttpOnly</code> cookie-based session auth, which would give browser clients a genuinely XSS-resistant option directly against this API.</p>
+
+<h3 id="token-lifetime">Token lifetime and refresh</h3>
+
+<p>Tokens are JWTs signed by the API. Expiry is set on the token itself; decode the JWT payload to read the <code>exp</code> claim if you need to know when to re-authenticate. There is currently no dedicated refresh endpoint &mdash; to obtain a new token, call <a href="#signin"><code>POST /signin</code></a> again. Plan for this in any long-lived integration.</p>
+
+<h2 id="conventions">Conventions</h2>
+
+<h3 id="request-format">Request and response format</h3>
+
+<ul>
+  <li>All request and response bodies are JSON. Send <code>Content-Type: application/json</code> on requests with a body.</li>
+  <li>The <code>Accept: application/json</code> header is recommended on all requests.</li>
+  <li>All endpoints return JSON unless explicitly noted (e.g. the HTML transcript endpoint).</li>
+  <li>Timestamps are ISO 8601 strings in UTC (e.g. <code>2024-01-15T14:26:14.086Z</code>).</li>
+</ul>
+
+<h3 id="field-naming">Field naming</h3>
+
+<p>Field names are inconsistent across the API: some use <code>snake_case</code> (<code>first_name</code>, <code>organizational_code</code>), others use <code>camelCase</code> (<code>maxProjectsAllowed</code>, <code>backgroundUrl</code>). Treat field names as case-sensitive and refer to the per-endpoint documentation for the exact spelling. Normalizing field naming is on our backlog.</p>
+
+<h3 id="internal-fields">Internal fields</h3>
+
+<p>Several responses include fields prefixed with an underscore (<code>_id</code>) or named <code>__v</code>. These are storage-layer internals that we currently expose for backwards compatibility. Treat them as read-only and avoid relying on <code>__v</code> in your application logic; we may remove or stop populating it in the future.</p>
+
+<h3 id="pagination">Pagination</h3>
+
+<p>Only <a href="#stories"><code>GET /stories</code></a> currently supports pagination, via <code>page</code> and <code>pageSize</code> query parameters. Other list endpoints (<code>/projects</code>, <code>/organization</code>) return all records the caller has access to. If you expect a large number of records, please contact us before integrating so we can advise.</p>
+
+<h2 id="api-endpoints">API endpoints</h2>
+
+<h3 id="signin">Sign in</h3>
+
+<p>Authenticates a user and returns user information along with an access token.</p>
+
+<div class="endpoint"><span class="method">POST</span>/signin</div>
+
+<h4>Request body</h4>
+
+<pre><code>{
   "email": "user@example.com",
   "password": "yourpassword"
 }</code></pre>
 
-        <div class="response-section">
-            <h4>Response:</h4>
-            <p>The response includes a JWT token and detailed information about the authenticated user.</p>
+<h4>Response</h4>
 
-            <h4>Response Fields:</h4>
-            <ul class="field-list">
-                <li><code>token</code>: JWT authentication token</li>
-                <li><code>full_name</code>: User's full name</li>
-                <li><code>user_id</code>: Unique identifier for the user</li>
-                <li><code>role</code>: User's role in the system (e.g., "admin")</li>
-                <li><code>email</code>: User's email address</li>
-                <li><code>user_details</code>: Detailed information about the user's profile</li>
-                <li><code>organization_info</code>: Information about the user's organization</li>
-                <li><code>api_version</code>: Version of the API</li>
-                <li><code>create_gallery</code>: Boolean permission for gallery creation</li>
-            </ul>
+<p>A JSON object containing a JWT token and detailed information about the authenticated user.</p>
 
-            <h4>Example Response:</h4>
-            <pre><code>{
-    "token": "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwiaHR0cHM6Ly90aGVpcnN0b3J5LmlvL3Zpc2l0b3ItaWQiOiIwYWIxMmNkMy00NTY3LTg5MDEtMjM0NS02N2FiOGNkZTkwZjEiLCJpYXQiOjE2MjM0NTY3ODl9.AbCdEfGhIjKlMnOpQrStUvWxYz",
-    "full_name": "John Doe",
-    "user_id": "1234567890abcdef",
-    "role": "admin",
+<h4>Response fields</h4>
+
+<table>
+  <thead>
+    <tr><th>Field</th><th>Type</th><th>Description</th></tr>
+  </thead>
+  <tbody>
+    <tr><td><code>token</code></td><td>string</td><td>JWT authentication token. Send as the raw <code>Authorization</code> header value on subsequent requests &mdash; see <a href="#auth-header">Authorization header format</a>.</td></tr>
+    <tr><td><code>full_name</code></td><td>string</td><td>User's full name.</td></tr>
+    <tr><td><code>user_id</code></td><td>string</td><td>Unique identifier for the user.</td></tr>
+    <tr><td><code>role</code></td><td>string</td><td>User's role (e.g. <code>admin</code>, <code>member</code>).</td></tr>
+    <tr><td><code>email</code></td><td>string</td><td>User's email address.</td></tr>
+    <tr><td><code>user_details</code></td><td>object</td><td>Detailed user profile. See below.</td></tr>
+    <tr><td><code>organization_info</code></td><td>object</td><td>User's primary organization. See below.</td></tr>
+    <tr><td><code>api_version</code></td><td>string</td><td>Version of the API that served the response.</td></tr>
+    <tr><td><code>create_gallery</code></td><td>boolean</td><td>Whether this user may create galleries.</td></tr>
+  </tbody>
+</table>
+
+<p><code>user_details</code> contains:</p>
+
+<table>
+  <thead>
+    <tr><th>Field</th><th>Type</th><th>Description</th></tr>
+  </thead>
+  <tbody>
+    <tr><td><code>id</code></td><td>number</td><td>Numeric user ID.</td></tr>
+    <tr><td><code>email</code></td><td>string</td><td>User's email.</td></tr>
+    <tr><td><code>first_name</code></td><td>string</td><td>User's first name.</td></tr>
+    <tr><td><code>last_name</code></td><td>string</td><td>User's last name.</td></tr>
+    <tr><td><code>photo_file_name</code></td><td>string | null</td><td>Filename of the user's photo, if any.</td></tr>
+    <tr><td><code>photo_content_type</code></td><td>string | null</td><td>MIME type of the user's photo, if any.</td></tr>
+    <tr><td><code>organizations</code></td><td>array</td><td>Organizations the user belongs to.</td></tr>
+  </tbody>
+</table>
+
+<p>Each entry in <code>organizations</code> contains <code>id</code>, <code>name</code>, <code>subdomain</code>, <code>custom_domain</code>, <code>description</code> (HTML), and <code>addresses[]</code>.</p>
+
+<p><code>organization_info</code> contains organization-level settings and quotas. See the <a href="#organization">Organization endpoint</a> for the field list &mdash; the same shape is used here.</p>
+
+<h4>Example response</h4>
+
+<pre><code>{
+  "token": "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.AbCdEfGh",
+  "full_name": "John Doe",
+  "user_id": "1234567890abcdef",
+  "role": "admin",
+  "email": "user@example.com",
+  "user_details": {
+    "id": 12345,
     "email": "user@example.com",
-    "user_details": {
-        "id": 12345,
-        "email": "user@example.com",
-        "first_name": "John",
-        "last_name": "Doe",
-        "photo_file_name": null,
-        "photo_content_type": null,
-        "organizations": [
-            {
-                "id": 67,
-                "name": "Example Organization",
-                "subdomain": "example",
-                "custom_domain": "",
-                "description": "<p>Example Organization is a platform that helps collect and preserve stories through interviews.</p>",
-                "addresses": [
-                    {
-                        "address_line_1": "123 Main Street",
-                        "address_line_2": "",
-                        "city": "Anytown",
-                        "state": "NY",
-                        "zipcode": "12345",
-                        "country": "US"
-                    }
-                ]
-            }
+    "first_name": "John",
+    "last_name": "Doe",
+    "photo_file_name": null,
+    "photo_content_type": null,
+    "organizations": [
+      {
+        "id": 67,
+        "name": "Example Organization",
+        "subdomain": "example",
+        "custom_domain": "",
+        "description": "Example Organization is a platform that helps collect and preserve stories through interviews.",
+        "addresses": [
+          {
+            "address_line_1": "123 Main Street",
+            "address_line_2": "",
+            "city": "Anytown",
+            "state": "NY",
+            "zipcode": "12345",
+            "country": "US"
+          }
         ]
+      }
+    ]
+  },
+  "organization_info": {
+    "_id": "abcdef1234567890",
+    "organization_name": "Example Admin",
+    "organizational_code": "example_admin_123456",
+    "permanent_org": {
+      "export_allowed": true,
+      "archive_nbr": "01ab-2345"
     },
-    "organization_info": {
-        "permanent_org": {
-            "export_allowed": true,
-            "archive_nbr": "01ab-2345"
-        },
-        "settings": {
-            "transcription_service": "cloudconvert",
-            "filler_words": false,
-            "vocabulary": [],
-            "auto_chaptering": true,
-            "summary_prompt": "Create a concise summary of this interview focusing on key topics discussed.",
-            "chaptering_prompt": "Create an index for this interview with timecodes, titles, summaries, and keywords."
-        },
-        "branding": false,
-        "_id": "abcdef1234567890",
-        "activity": true,
-        "org_manager_view_all": true,
-        "export_allowed": true,
-        "require_session_passwords": false,
-        "local_recordings_allowed": true,
-        "groups": [
-            "group123",
-            "group456",
-            "group789"
-        ],
-        "organization_name": "Example Admin",
-        "organizational_code": "example_admin_123456",
-        "created_at": "2023-01-15T12:30:45.678Z",
-        "__v": 5,
-        "allow_dial_in": true,
-        "local_recordings_polyfill": false,
-        "credits": 1000000,
-        "maxProjectsAllowed": 200,
-        "projects": 150,
-        "recording_hours": 320,
-        "backgroundUrl": "uploads/projectbackgrounds/example-background-image.jpg"
+    "settings": {
+      "transcription_service": "cloudconvert",
+      "filler_words": false,
+      "vocabulary": [],
+      "auto_chaptering": true,
+      "summary_prompt": "Create a concise summary of this interview focusing on key topics discussed.",
+      "chaptering_prompt": "Create an index for this interview with timecodes, titles, summaries, and keywords."
     },
-    "api_version": "1.2.3",
-    "create_gallery": true
+    "branding": false,
+    "activity": true,
+    "org_manager_view_all": true,
+    "export_allowed": true,
+    "require_session_passwords": false,
+    "local_recordings_allowed": true,
+    "allow_dial_in": true,
+    "local_recordings_polyfill": false,
+    "groups": ["group123", "group456", "group789"],
+    "credits": 1000000,
+    "maxProjectsAllowed": 200,
+    "projects": 150,
+    "recording_hours": 320,
+    "backgroundUrl": "uploads/projectbackgrounds/example-background-image.jpg",
+    "created_at": "2023-01-15T12:30:45.678Z",
+    "__v": 5
+  },
+  "api_version": "1.2.3",
+  "create_gallery": true
 }</code></pre>
-        </div>
-       
 
-        <h4>Example code:</h4>
-        <div class="example-code">
-            <pre><code>
-            fetch('https://node.theirstory.io/signin', {
-                method: 'POST',
-                headers: {
-                    'Content-Type': 'application/json',
-                    'Accept': 'application/json, text/plain, */*'
-                },
-                body: JSON.stringify({
-                    email: email,
-                    password: password
-                })
-            })
-            .then(response => {
-                if (response.ok) {
-                    return response.json();
-                }
-                throw new Error('Login failed');
-            })
-            .then(data => {
-                showMessage('Login successful! Redirecting...', 'success');
-                // Store the token in localStorage for use in the organizations page
-                localStorage.setItem('authToken', data.token);
-                // Redirect to the front page
-                setTimeout(() => {
-                    window.location.href = 'frontpage.html';
-                }, 1500);
-            })
-            .catch(error => {
-                showMessage('Login failed. Please check your credentials.', 'error');
-                console.error('Error:', error);
-            });
-        </div>
-            </code></pre>
-        </section>
+<h4>Example code</h4>
 
-        <div class="endpoint-divider"></div>
+<pre><code>const response = await fetch('https://node.theirstory.io/signin', {
+  method: 'POST',
+  headers: {
+    'Content-Type': 'application/json',
+    'Accept': 'application/json'
+  },
+  body: JSON.stringify({ email, password })
+});
 
-        <section id="current-user">
-            <h3>Current User Information</h3>
-        <p>Retrieves information about the currently authenticated user.</p>
+if (!response.ok) {
+  throw new Error('Login failed');
+}
 
-        <div class="endpoint-url">
-            <span class="http-method">GET</span>
-            <code>https://node.theirstory.io/current_user</code>
-            <button class="copy-btn" onclick="copyToClipboard('https://node.theirstory.io/current_user')">
-                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                    <path d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2"></path>
-                    <rect x="8" y="2" width="8" height="4" rx="1" ry="1"></rect>
-                </svg>
-            </button>
-        </div>
+const data = await response.json();
 
-        <h4>Query Parameters:</h4>
-        <ul>
-            <li><code>visitorId</code> (required): Unique identifier for the visitor/session</li>
-        </ul>
+// See "Token storage in browser clients" for tradeoffs.
+// localStorage is convenient but XSS-readable.
+localStorage.setItem('authToken', data.token);</code></pre>
 
-        <h4>Example Request:</h4>
-        <div class="endpoint-url">
-            <span class="http-method">GET</span>
-            <code>https://node.theirstory.io/current_user?visitorId=7fe32a19-84c5-4921-b517-29d7c8e54f3a</code>
-            <button class="copy-btn" onclick="copyToClipboard('https://node.theirstory.io/current_user?visitorId=7fe32a19-84c5-4921-b517-29d7c8e54f3a')">
-                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                    <path d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2"></path>
-                    <rect x="8" y="2" width="8" height="4" rx="1" ry="1"></rect>
-                </svg>
-            </button>
-        </div>
+<blockquote class="note">
+  <p><strong>Note on <code>export_allowed</code> vs <code>aviary_export_allowed</code>:</strong> Some organizations use <code>aviary_export_allowed</code> in place of <code>export_allowed</code> to indicate permission to export to Aviary specifically. If both are present, treat <code>aviary_export_allowed</code> as the more specific flag. Both fields are returned as-is and we are working to consolidate them.</p>
+</blockquote>
 
-        <div class="response-section">
-            <h4>Response:</h4>
-            <p>The response includes detailed information about the user, their role, associated organizations, and feature access.</p>
+<h3 id="current-user">Current user information</h3>
 
-            <h4>Response Fields:</h4>
-            <ul class="field-list">
-                <li><code>token</code>: JWT authentication token</li>
-                <li><code>full_name</code>: User's full name</li>
-                <li><code>user_id</code>: Unique identifier for the user</li>
-                <li><code>role</code>: User's role in the system (e.g., "admin")</li>
-                <li><code>email</code>: User's email address</li>
-                <li><code>user_details</code>: Detailed information about the user's profile
-                    <ul>
-                        <li><code>id</code>: User ID</li>
-                        <li><code>email</code>: User's email</li>
-                        <li><code>first_name</code>: User's first name</li>
-                        <li><code>last_name</code>: User's last name</li>
-                        <li><code>photo_file_name</code>: Optional filename for user's photo</li>
-                        <li><code>photo_content_type</code>: Media type of user's photo</li>
-                        <li><code>organizations</code>: List of organizations the user belongs to
-                            <ul>
-                                <li><code>id</code>: Organization ID</li>
-                                <li><code>name</code>: Organization name</li>
-                                <li><code>subdomain</code>: Organization subdomain</li>
-                                <li><code>custom_domain</code>: Optional custom domain</li>
-                                <li><code>description</code>: HTML description of the organization</li>
-                                <li><code>addresses</code>: Physical addresses associated with the organization</li>
-                            </ul>
-                        </li>
-                    </ul>
-                </li>
-                <li><code>organization_info</code>: Information about the user's organization
-                    <ul>
-                        <li><code>permanent_org</code>: Permanent organization details</li>
-                        <li><code>settings</code>: Organization-specific settings
-                            <ul>
-                                <li><code>transcription_service</code>: Service used for transcription</li>
-                                <li><code>filler_words</code>: Boolean to include/exclude filler words in transcription</li>
-                                <li><code>vocabulary</code>: Custom vocabulary for transcription</li>
-                                <li><code>auto_chaptering</code>: Boolean for automatic chapter creation</li>
-                                <li><code>summary_prompt</code>: Prompt used for generating summaries</li>
-                                <li><code>chaptering_prompt</code>: Prompt used for generating chapters</li>
-                            </ul>
-                        </li>
-                        <li><code>branding</code>: Boolean for custom branding</li>
-                        <li><code>activity</code>: Boolean for activity tracking</li>
-                        <li><code>org_manager_view_all</code>: Permission setting for organization managers</li>
-                        <li><code>export_allowed</code>: Boolean for export permission</li>
-                        <li><code>require_session_passwords</code>: Boolean for session password requirement</li>
-                        <li><code>local_recordings_allowed</code>: Boolean for local recording permission</li>
-                        <li><code>groups</code>: List of group IDs</li>
-                        <li><code>organization_name</code>: Name of the organization</li>
-                        <li><code>organizational_code</code>: Unique code for the organization</li>
-                        <li><code>credits</code>: Available credits</li>
-                        <li><code>maxProjectsAllowed</code>: Maximum number of allowed projects</li>
-                        <li><code>projects</code>: Current number of projects</li>
-                        <li><code>recording_hours</code>: Hours of recordings</li>
-                    </ul>
-                </li>
-                <li><code>api_version</code>: Version of the API</li>
-                <li><code>create_gallery</code>: Boolean permission for gallery creation</li>
-            </ul>
+<p>Retrieves information about the currently authenticated user.</p>
 
-            <h4>Example Response:</h4>
-            <pre><code>{
-    "token": "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiI4NDc2MjkzOTQ4NjMzIiwiaHR0cHM6Ly90aGVpcnN0b3J5LmlvL3Zpc2l0b3ItaWQiOiI3ZmUzMmExOS04NGM1LTQ5MjEtYjUxNy0yOWQ3YzhlNTRmM2EiLCJpYXQiOjE3MzM0ODUyMDF9.AoBg5ub7DvhJxYz8KpLn",
-    "full_name": "Jane Smith",
-    "user_id": "847629394863",
-    "role": "admin",
+<div class="endpoint"><span class="method">GET</span>/current_user?visitorId={visitorId}</div>
+
+<h4>Query parameters</h4>
+
+<table>
+  <thead>
+    <tr><th>Parameter</th><th>Required</th><th>Description</th></tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>visitorId</code></td>
+      <td>yes</td>
+      <td>The visitor ID associated with this session. The value is embedded in your JWT's <code>visitor-id</code> claim &mdash; decode the JWT payload to retrieve it, or persist the value your client generated at sign-in.</td>
+    </tr>
+  </tbody>
+</table>
+
+<h4>Example request</h4>
+
+<pre><code>GET /current_user?visitorId=7fe32a19-84c5-4921-b517-29d7c8e54f3a
+Authorization: &lt;jwt&gt;</code></pre>
+
+<h4>Response</h4>
+
+<p>Same shape as the <a href="#signin">Sign in</a> response, including a refreshed <code>token</code>. The user may belong to multiple organizations; <code>user_details.organizations</code> is an array.</p>
+
+<h4>Example response (abbreviated)</h4>
+
+<pre><code>{
+  "token": "eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9...",
+  "full_name": "Jane Smith",
+  "user_id": "847629394863",
+  "role": "admin",
+  "email": "jane.smith@example.com",
+  "user_details": {
+    "id": 12345,
     "email": "jane.smith@example.com",
-    "user_details": {
-        "id": 12345,
-        "email": "jane.smith@example.com",
-        "first_name": "Jane",
-        "last_name": "Smith",
-        "photo_file_name": null,
-        "photo_content_type": null,
-        "organizations": [
-            {
-                "id": 78,
-                "name": "Community Archives Project",
-                "subdomain": "communityarchives",
-                "custom_domain": "",
-                "description": "<p>The Community Archives Project collects and preserves local stories through audio and video interviews.</p>",
-                "addresses": [
-                    {
-                        "address_line_1": "123 Main Street",
-                        "address_line_2": "Suite 405",
-                        "city": "Riverdale",
-                        "state": "NY",
-                        "zipcode": "10463",
-                        "country": "US"
-                    }
-                ]
-            },
-            {
-                "id": 92,
-                "name": "Metro Historical Society",
-                "subdomain": "metrohistory",
-                "custom_domain": "",
-                "description": "<p>The Metro Historical Society works to document and preserve the cultural heritage of our city's diverse communities.</p>",
-                "addresses": [
-                    {
-                        "address_line_1": "456 Heritage Avenue",
-                        "address_line_2": "",
-                        "city": "Metro City",
-                        "state": "CA",
-                        "zipcode": "90210",
-                        "country": "US"
-                    }
-                ]
-            }
-        ]
-    },
-
-    "organization_info": {
-        "permanent_org": {
-            "export_allowed": true,
-            "archive_nbr": "07kp-2341"
-        },
-        "settings": {
-            "transcription_service": "cloudconvert",
-            "filler_words": false,
-            "vocabulary": ["genealogy", "archives", "cultural heritage"],
-            "auto_chaptering": true,
-            "summary_prompt": "Create a concise summary of this oral history interview focusing on the key topics, historical events, and personal experiences discussed.",
-            "chaptering_prompt": "Divide this interview into logical chapters based on topic changes and significant moments. Each chapter should include a timecode, title, brief summary, and relevant keywords."
-        },
-        "branding": true,
-        "_id": "6ab92cd3e7f14502937654a2",
-        "activity": true,
-        "org_manager_view_all": true,
-        "aviary_export_allowed": true,
-        "require_session_passwords": true,
-        "local_recordings_allowed": true,
-        "groups": [
-            "7ac892d3f4e25613ba98765c",
-            "8bd903e4g5f36724cb09876d",
-            "9ce014f5h6g47835dc10987e"
-        ],
-        "organization_name": "Community Archives Admin",
-        "organizational_code": "ca_admin_854237",
-        "created_at": "2023-04-15T14:27:42.519Z",
-        "__v": 5,
-        "allow_dial_in": true,
-        "local_recordings_polyfill": false,
-        "credits": 1750000,
-        "maxProjectsAllowed": 300,
-        "projects": 187,
-        "recording_hours": 428,
-        "backgroundUrl": "uploads/projectbackgrounds/KpL8sMnO7qRtUvWxYz9A.jpg"
-    },
-    "api_version": "2.7.4",
-    "create_gallery": true
+    "first_name": "Jane",
+    "last_name": "Smith",
+    "organizations": [
+      { "id": 78, "name": "Community Archives Project", "subdomain": "communityarchives" },
+      { "id": 92, "name": "Metro Historical Society",   "subdomain": "metrohistory" }
+    ]
+  },
+  "organization_info": { "...": "see Sign in response" },
+  "api_version": "1.2.3",
+  "create_gallery": true
 }</code></pre>
-        </div>
-        </section>
 
-        <div class="endpoint-divider"></div>
+<h3 id="projects">Projects</h3>
 
-        <section id="projects">
-            <h3>Projects</h3>
-        <p>Retrieves information about projects the user has access to.</p>
+<p>Retrieves projects the authenticated user has access to.</p>
 
-        <div class="endpoint-url">
-            <span class="http-method">GET</span>
-            <code>https://node.theirstory.io/projects</code>
-            <button class="copy-btn" onclick="copyToClipboard('https://node.theirstory.io/projects')">
-                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                    <path d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2"></path>
-                    <rect x="8" y="2" width="8" height="4" rx="1" ry="1"></rect>
-                </svg>
-            </button>
-        </div>
+<div class="endpoint"><span class="method">GET</span>/projects</div>
 
-        <div class="response-section">
-            <h4>Response:</h4>
-            <p>The response is an array of project objects with details about each project.</p>
+<h4>Response</h4>
 
-            <h4>Response Fields:</h4>
-            <ul class="field-list">
-                <li><code>_id</code>: Unique identifier for the project</li>
-                <li><code>name</code>: Name of the project</li>
-                <li><code>description</code>: Description of the project</li>
-                <li><code>creator</code>: ID of the user who created the project</li>
-                <li><code>backgroundUrl</code>: Path to the background image</li>
-                <li><code>displayTitle</code>: Boolean indicating if the title should be displayed</li>
-                <li><code>defaultProjectForOrganization</code>: Boolean indicating if this is the default project</li>
-                <li><code>organization</code>: Organization ID that owns the project</li>
-                <li><code>created_at</code>: Timestamp of when the project was created</li>
-                <li><code>__v</code>: Version number</li>
-                <li><code>view_only_code</code>: Code for view-only access</li>
-                <li><code>view_only_code_created_at</code>: Timestamp when view-only code was created</li>
-                <li><code>member_code</code>: Code for member access</li>
-                <li><code>member_code_created_at</code>: Timestamp when member code was created</li>
-                <li><code>project_manager_code</code>: Code for project manager access</li>
-                <li><code>project_manager_code_created_at</code>: Timestamp when project manager code was created</li>
-                <li><code>projectBackgroundUrl</code>: Full URL to the background image</li>
-                <li><code>folders</code>: Array of folder objects belonging to the project
-                    <ul>
-                        <li><code>_id</code>: Unique identifier for the folder</li>
-                        <li><code>name</code>: Name of the folder</li>
-                        <li><code>creator</code>: ID of the user who created the folder</li>
-                        <li><code>project</code>: Project ID the folder belongs to</li>
-                        <li><code>defaultFolderForProject</code>: Boolean indicating if this is the default folder</li>
-                        <li><code>created_at</code>: Timestamp of when the folder was created</li>
-                        <li><code>__v</code>: Version number</li>
-                        <li><code>fu</code>: Array of folder user objects
-                            <ul>
-                                <li><code>_id</code>: Unique identifier for the folder user relationship</li>
-                                <li><code>user</code>: User ID</li>
-                                <li><code>accepted</code>: Boolean indicating if the user accepted the folder invitation</li>
-                                <li><code>creator</code>: Boolean indicating if the user is the creator</li>
-                                <li><code>folder</code>: Folder ID</li>
-                                <li><code>created_at</code>: Timestamp when the relationship was created</li>
-                                <li><code>__v</code>: Version number</li>
-                            </ul>
-                        </li>
-                    </ul>
-                </li>
-                <li><code>organizationName</code>: Name of the organization the project belongs to</li>
-                <li><code>storiesInProject</code>: Count of stories in the project</li>
-                <li><code>isManager</code>: Boolean indicating if the current user is a manager of this project</li>
-            </ul>
+<p>An array of project objects.</p>
 
-            <h4>Example Response:</h4>
-            <pre><code>[
+<h4>Response fields</h4>
+
+<table>
+  <thead>
+    <tr><th>Field</th><th>Type</th><th>Description</th></tr>
+  </thead>
+  <tbody>
+    <tr><td><code>_id</code></td><td>string</td><td>Unique identifier for the project.</td></tr>
+    <tr><td><code>name</code></td><td>string</td><td>Project name.</td></tr>
+    <tr><td><code>description</code></td><td>string</td><td>Project description.</td></tr>
+    <tr><td><code>creator</code></td><td>string</td><td>User ID of the project's creator.</td></tr>
+    <tr><td><code>backgroundUrl</code></td><td>string</td><td>Storage path to the background image.</td></tr>
+    <tr><td><code>projectBackgroundUrl</code></td><td>string</td><td>Fully resolved URL to the background image.</td></tr>
+    <tr><td><code>displayTitle</code></td><td>boolean</td><td>Whether to display the project title in the UI.</td></tr>
+    <tr><td><code>defaultProjectForOrganization</code></td><td>boolean</td><td>Whether this is the organization's default project.</td></tr>
+    <tr><td><code>organization</code></td><td>string</td><td>Organization ID that owns the project.</td></tr>
+    <tr><td><code>organizationName</code></td><td>string</td><td>Name of the owning organization.</td></tr>
+    <tr><td><code>view_only_code</code></td><td>string</td><td>Invitation code for view-only access.</td></tr>
+    <tr><td><code>view_only_code_created_at</code></td><td>string</td><td>When the view-only code was created (ISO 8601).</td></tr>
+    <tr><td><code>member_code</code></td><td>string</td><td>Invitation code for member access.</td></tr>
+    <tr><td><code>member_code_created_at</code></td><td>string</td><td>When the member code was created.</td></tr>
+    <tr><td><code>project_manager_code</code></td><td>string</td><td>Invitation code for project manager access.</td></tr>
+    <tr><td><code>project_manager_code_created_at</code></td><td>string</td><td>When the project manager code was created.</td></tr>
+    <tr><td><code>folders</code></td><td>array</td><td>Folders in the project. See below.</td></tr>
+    <tr><td><code>storiesInProject</code></td><td>number</td><td>Total stories in the project.</td></tr>
+    <tr><td><code>isManager</code></td><td>boolean</td><td>Whether the authenticated user manages this project.</td></tr>
+    <tr><td><code>created_at</code></td><td>string</td><td>When the project was created.</td></tr>
+    <tr><td><code>__v</code></td><td>number</td><td>Internal version (see <a href="#internal-fields">Internal fields</a>).</td></tr>
+  </tbody>
+</table>
+
+<p>Each folder contains: <code>_id</code>, <code>name</code>, <code>creator</code>, <code>project</code>, <code>defaultFolderForProject</code>, <code>created_at</code>, <code>__v</code>, and an <code>fu</code> array of folder-user relationships. Each <code>fu</code> entry contains: <code>_id</code>, <code>user</code>, <code>accepted</code>, <code>creator</code>, <code>folder</code>, <code>created_at</code>, <code>__v</code>.</p>
+
+<blockquote class="warn">
+  <p><strong>Invitation codes are sensitive.</strong> <code>view_only_code</code>, <code>member_code</code>, and <code>project_manager_code</code> grant access to the project. Treat them like passwords: don't log them, don't surface them in URLs you share publicly, and don't include them in browser-visible code unless the user is supposed to be sharing them.</p>
+</blockquote>
+
+<h4>Example response</h4>
+
+<pre><code>[
   {
     "_id": "proj123456789",
     "name": "Community Archives",
@@ -607,8 +598,7 @@
     "displayTitle": true,
     "defaultProjectForOrganization": false,
     "organization": "org123456789",
-    "created_at": "2024-01-15T14:26:14.086Z",
-    "__v": 0,
+    "organizationName": "Community Archives Organization",
     "view_only_code": "aBcD1234EfGh5i6",
     "view_only_code_created_at": "2024-01-15T14:26:58.682Z",
     "member_code": "jKlM7890nOpQ1r2",
@@ -638,141 +628,107 @@
         ]
       }
     ],
-    "organizationName": "Community Archives Organization",
     "storiesInProject": 32,
-    "isManager": true
-  },
-  {
-    "_id": "proj987654321",
-    "name": "Oral History Collection",
-    "description": "Collection of oral histories from community members",
-    "creator": "user123456789",
-    "backgroundUrl": "uploads/projectbackgrounds/oral-history-bg.jpg",
-    "displayTitle": true,
-    "defaultProjectForOrganization": false,
-    "organization": "org987654321",
-    "created_at": "2024-02-10T19:08:14.209Z",
-    "__v": 0,
-    "view_only_code": "bCdE2345fGhI6j7",
-    "view_only_code_created_at": "2024-02-10T19:36:20.241Z",
-    "member_code": "kLmN8901oPqR2s3",
-    "member_code_created_at": "2024-02-25T15:50:06.822Z",
-    "projectBackgroundUrl": "https://storage.example.com/uploads/projectbackgrounds/oral-history-bg.jpg?token=def456",
-    "folders": [],
-    "organizationName": "Oral History Foundation",
-    "storiesInProject": 18,
-    "isManager": false
+    "isManager": true,
+    "created_at": "2024-01-15T14:26:14.086Z",
+    "__v": 0
   }
 ]</code></pre>
-        </div>
-        </section>
 
-        <div class="endpoint-divider"></div>
+<h3 id="organization">Organization</h3>
 
-        <section id="organization">
-            <h3>Organization</h3>
-        <p>Retrieves information about organizations that the user has access to.</p>
+<p>Retrieves the organizations the authenticated user has access to.</p>
 
-        <div class="endpoint-url">
-            <span class="http-method">GET</span>
-            <code>https://node.theirstory.io/organization</code>
-            <button class="copy-btn" onclick="copyToClipboard('https://node.theirstory.io/organization')">
-                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                    <path d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2"></path>
-                    <rect x="8" y="2" width="8" height="4" rx="1" ry="1"></rect>
-                </svg>
-            </button>
-        </div>
+<div class="endpoint"><span class="method">GET</span>/organization</div>
 
-        <div class="response-section">
-            <h4>Response:</h4>
-            <p>The response includes an array of organization objects with details about each organization the user has access to.</p>
+<h4>Response</h4>
 
-            <h4>Response Fields:</h4>
-            <ul class="field-list">
-                <li><code>organizations</code>: Array of organization objects, each containing:
-                    <ul>
-                        <li><code>_id</code>: Unique identifier for the organization</li>
-                        <li><code>activity</code>: Boolean indicating if the organization is active</li>
-                        <li><code>org_manager_view_all</code>: Boolean controlling manager view permissions</li>
-                        <li><code>export_allowed</code>: Boolean for export permission</li>
-                        <li><code>require_session_passwords</code>: Boolean for session password requirement</li>
-                        <li><code>groups</code>: Array of group IDs</li>
-                        <li><code>organization_name</code>: Name of the organization</li>
-                        <li><code>organizational_code</code>: Unique code for the organization</li>
-                        <li><code>created_at</code>: Creation timestamp</li>
-                        <li><code>__v</code>: Version number</li>
-                        <li><code>local_recordings_polyfill</code>: Boolean to enable recording polyfill</li>
-                        <li><code>allow_dial_in</code>: Boolean to allow dial-in functionality</li>
-                        <li><code>local_recordings_allowed</code>: Boolean for local recording permission</li>
-                        <li><code>permanent_org</code>: Object with organization permanence details</li>
-                        <li><code>credits</code>: Available credits</li>
-                        <li><code>backgroundUrl</code>: URL to the organization's background image</li>
-                        <li><code>maxProjectsAllowed</code>: Maximum number of allowed projects</li>
-                        <li><code>projects</code>: Current number of projects</li>
-                        <li><code>recording_hours</code>: Available recording hours</li>
-                        <li><code>branding</code>: Boolean for custom branding</li>
-                        <li><code>settings</code>: Object with organization settings
-                            <ul>
-                                <li><code>transcription_service</code>: Service used for transcription</li>
-                                <li><code>filler_words</code>: Boolean to include/exclude filler words</li>
-                                <li><code>vocabulary</code>: Array of custom vocabulary words</li>
-                                <li><code>auto_chaptering</code>: Boolean for automatic chapter creation</li>
-                                <li><code>summary_prompt</code>: Prompt for summary generation</li>
-                                <li><code>chaptering_prompt</code>: Prompt for chapter generation</li>
-                            </ul>
-                        </li>
-                        <li><code>users</code>: Array of user objects belonging to the organization</li>
-                    </ul>
-                </li>
-            </ul>
+<p>An object containing a single <code>organizations</code> array.</p>
 
-            <h4>Example Response:</h4>
-            <pre><code>{
+<h4>Response fields</h4>
+
+<p>Each organization in the array contains:</p>
+
+<table>
+  <thead>
+    <tr><th>Field</th><th>Type</th><th>Description</th></tr>
+  </thead>
+  <tbody>
+    <tr><td><code>_id</code></td><td>string</td><td>Unique identifier for the organization.</td></tr>
+    <tr><td><code>organization_name</code></td><td>string</td><td>Display name.</td></tr>
+    <tr><td><code>organizational_code</code></td><td>string</td><td>Unique slug-style code.</td></tr>
+    <tr><td><code>activity</code></td><td>boolean</td><td>Whether the organization is active.</td></tr>
+    <tr><td><code>org_manager_view_all</code></td><td>boolean</td><td>Whether org managers can view all projects.</td></tr>
+    <tr><td><code>export_allowed</code></td><td>boolean</td><td>General export permission.</td></tr>
+    <tr><td><code>aviary_export_allowed</code></td><td>boolean</td><td>Aviary-specific export permission (when present).</td></tr>
+    <tr><td><code>require_session_passwords</code></td><td>boolean</td><td>Whether recording sessions require passwords.</td></tr>
+    <tr><td><code>local_recordings_allowed</code></td><td>boolean</td><td>Whether local recordings are permitted.</td></tr>
+    <tr><td><code>local_recordings_polyfill</code></td><td>boolean</td><td>Whether the local-recording polyfill is enabled.</td></tr>
+    <tr><td><code>allow_dial_in</code></td><td>boolean</td><td>Whether dial-in recording is enabled.</td></tr>
+    <tr><td><code>branding</code></td><td>boolean</td><td>Whether custom branding is enabled.</td></tr>
+    <tr><td><code>groups</code></td><td>array</td><td>IDs of groups in the organization.</td></tr>
+    <tr><td><code>permanent_org</code></td><td>object</td><td>Permanence details (<code>export_allowed</code>, <code>archive_nbr</code>).</td></tr>
+    <tr><td><code>settings</code></td><td>object</td><td>Transcription/AI settings; see below.</td></tr>
+    <tr><td><code>users</code></td><td>array</td><td>Users in the organization; see below.</td></tr>
+    <tr><td><code>credits</code></td><td>number</td><td>Available credits.</td></tr>
+    <tr><td><code>maxProjectsAllowed</code></td><td>number</td><td>Project quota.</td></tr>
+    <tr><td><code>projects</code></td><td>number</td><td>Current project count.</td></tr>
+    <tr><td><code>recording_hours</code></td><td>number</td><td>Recording-hour quota.</td></tr>
+    <tr><td><code>backgroundUrl</code></td><td>string</td><td>Storage path to the organization's background image.</td></tr>
+    <tr><td><code>created_at</code></td><td>string</td><td>Creation timestamp.</td></tr>
+    <tr><td><code>__v</code></td><td>number</td><td>Internal version.</td></tr>
+  </tbody>
+</table>
+
+<p><code>settings</code> contains:</p>
+
+<table>
+  <thead>
+    <tr><th>Field</th><th>Type</th><th>Description</th></tr>
+  </thead>
+  <tbody>
+    <tr><td><code>transcription_service</code></td><td>string</td><td>Transcription provider (e.g. <code>cloudconvert</code>).</td></tr>
+    <tr><td><code>filler_words</code></td><td>boolean</td><td>Whether filler words are kept in transcripts.</td></tr>
+    <tr><td><code>vocabulary</code></td><td>array</td><td>Custom vocabulary terms for transcription.</td></tr>
+    <tr><td><code>auto_chaptering</code></td><td>boolean</td><td>Whether automatic chaptering is enabled.</td></tr>
+    <tr><td><code>summary_prompt</code></td><td>string</td><td>LLM prompt used for summary generation.</td></tr>
+    <tr><td><code>chaptering_prompt</code></td><td>string</td><td>LLM prompt used for chapter generation.</td></tr>
+  </tbody>
+</table>
+
+<p>Each user in <code>users</code> contains: <code>_id</code>, <code>is_verified</code>, <code>role</code>, <code>stories</code>, <code>full_name</code>, <code>email</code>, <code>organization</code>, <code>signed_up</code>, <code>__v</code>, <code>create_gallery</code>, and <code>featureFlags</code> (an object with <code>enableTwilioVideo</code>, <code>localRecordingMimeType</code>, <code>disableAutomaticResolutionSwitching</code>, <code>autoChaptering</code>, <code>_id</code>).</p>
+
+<h4>Example response (abbreviated)</h4>
+
+<pre><code>{
   "organizations": [
     {
       "_id": "org123456789",
+      "organization_name": "Community Archives Project",
+      "organizational_code": "cap_admin_2023",
       "activity": true,
       "org_manager_view_all": true,
       "aviary_export_allowed": true,
       "require_session_passwords": false,
       "groups": ["group1234", "group5678", "group9012"],
-      "organization_name": "Community Archives Project",
-      "organizational_code": "cap_admin_2023",
-      "created_at": "2023-04-15T14:27:42.519Z",
-      "__v": 5,
-      "local_recordings_polyfill": false,
-      "allow_dial_in": true,
-      "local_recordings_allowed": true,
-      "permanent_org": {
-        "export_allowed": true,
-        "archive_nbr": "07kp-2341"
-      },
-      "credits": 1750000,
-      "backgroundUrl": "uploads/projectbackgrounds/community-archives-bg.jpg",
-      "maxProjectsAllowed": 300,
-      "projects": 187,
-      "recording_hours": 428,
-      "branding": true,
+      "permanent_org": { "export_allowed": true, "archive_nbr": "07kp-2341" },
       "settings": {
         "transcription_service": "cloudconvert",
         "filler_words": false,
         "vocabulary": ["oral history", "archives", "cultural heritage"],
         "auto_chaptering": true,
-        "summary_prompt": "Create a concise summary of this oral history interview focusing on the key topics, historical events, and personal experiences discussed.",
-        "chaptering_prompt": "Divide this interview into logical chapters based on topic changes and significant moments."
+        "summary_prompt": "Create a concise summary...",
+        "chaptering_prompt": "Divide this interview into logical chapters..."
       },
       "users": [
         {
           "_id": "user123456",
           "is_verified": false,
           "role": "admin",
-          "stories": [],
           "full_name": "Emma Johnson",
           "email": "emma.johnson@example.com",
           "organization": "org123456789",
           "signed_up": "2023-05-12T15:32:47.821Z",
-          "__v": 0,
           "create_gallery": true,
           "featureFlags": {
             "enableTwilioVideo": true,
@@ -780,407 +736,316 @@
             "disableAutomaticResolutionSwitching": false,
             "autoChaptering": true,
             "_id": "flag123456"
-          }
+          },
+          "__v": 0
         }
-      ]
+      ],
+      "credits": 1750000,
+      "maxProjectsAllowed": 300,
+      "projects": 187,
+      "recording_hours": 428,
+      "backgroundUrl": "uploads/projectbackgrounds/community-archives-bg.jpg",
+      "branding": true,
+      "created_at": "2023-04-15T14:27:42.519Z",
+      "__v": 5
     }
   ]
 }</code></pre>
-        </div>
-        </section>
 
-        <div class="endpoint-divider"></div>
+<h3 id="stories">Stories</h3>
 
-        <section id="stories">
-            <h3>Stories</h3>
-        <p>Retrieves information about stories (recordings) with pagination support.</p>
+<p>Retrieves stories (recordings) accessible to the authenticated user, with pagination.</p>
 
-        <div class="endpoint-url">
-            <span class="http-method">GET</span>
-            <code>https://node.theirstory.io/stories/</code>
-            <button class="copy-btn" onclick="copyToClipboard('https://node.theirstory.io/stories/')">
-                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                    <path d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2"></path>
-                    <rect x="8" y="2" width="8" height="4" rx="1" ry="1"></rect>
-                </svg>
-            </button>
-        </div>
+<div class="endpoint"><span class="method">GET</span>/stories?page={page}&amp;pageSize={pageSize}</div>
 
-        <h4>Query Parameters:</h4>
-        <ul>
-            <li><code>pageSize</code> (optional): Number of items per page (default: 15)</li>
-            <li><code>page</code> (optional): Page number to retrieve (default: 1)</li>
-        </ul>
+<h4>Query parameters</h4>
 
-        <div class="endpoint-url">
-            <span class="http-method">GET</span>
-            <code>https://node.theirstory.io/stories/?pageSize=15&page=1</code>
-            <button class="copy-btn" onclick="copyToClipboard('https://node.theirstory.io/stories/?pageSize=15&page=1')">
-                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                    <path d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2"></path>
-                    <rect x="8" y="2" width="8" height="4" rx="1" ry="1"></rect>
-                </svg>
-            </button>
-        </div>
+<table>
+  <thead>
+    <tr><th>Parameter</th><th>Required</th><th>Default</th><th>Description</th></tr>
+  </thead>
+  <tbody>
+    <tr><td><code>page</code></td><td>no</td><td><code>1</code></td><td>Page number (1-indexed).</td></tr>
+    <tr><td><code>pageSize</code></td><td>no</td><td><code>15</code></td><td>Items per page.</td></tr>
+  </tbody>
+</table>
 
-        <div class="response-section">
-            <h4>Response:</h4>
-            <p>The response includes pagination information and an array of story objects with comprehensive details about each recording.</p>
+<h4>Response fields</h4>
 
-            <h4>Response Fields:</h4>
-            <ul class="field-list">
-                <li><code>page</code>: Current page number</li>
-                <li><code>total</code>: Total number of stories</li>
-                <li><code>items</code>: Array of story objects, each containing details about the recording</li>
-            </ul>
-        </div>
+<table>
+  <thead>
+    <tr><th>Field</th><th>Type</th><th>Description</th></tr>
+  </thead>
+  <tbody>
+    <tr><td><code>page</code></td><td>number</td><td>Current page number.</td></tr>
+    <tr><td><code>total</code></td><td>number</td><td>Total stories matching the request.</td></tr>
+    <tr><td><code>items</code></td><td>array</td><td>Story objects on this page; see below.</td></tr>
+  </tbody>
+</table>
 
-        <h3 id="transcript-json">Get Story Transcript JSON</h3>
-        <p>Retrieves the transcript of a specific story in JSON format, including words, timestamps, and other transcript metadata.</p>
+<p>Each story object contains at minimum: <code>_id</code>, <code>title</code>, <code>record_date</code> (ISO 8601), <code>duration</code> (seconds), <code>author</code>, <code>indexes</code> (chapter metadata), and <code>asyncOperations</code> (processing history). The full per-story shape matches the <code>story</code> field in the <a href="#transcript-json">transcript JSON response</a> &mdash; use that as the canonical reference.</p>
 
-        <div class="endpoint-url">
-            <span class="http-method">GET</span>
-            <code>https://node.theirstory.io/transcripts/{storyid}</code>
-            <button class="copy-btn" onclick="copyToClipboard('https://node.theirstory.io/transcripts/{storyid}')">
-                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                    <path d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2"></path>
-                    <rect x="8" y="2" width="8" height="4" rx="1" ry="1"></rect>
-                </svg>
-            </button>
-        </div>
+<h4>Example response</h4>
 
-        <h4>Path Parameters:</h4>
-        <ul>
-            <li><code>storyid</code> (required): The unique identifier of the story</li>
-        </ul>
-
-        <div class="response-section">
-            <h4>Response:</h4>
-            <p>The response is a JSON object containing detailed transcript information, story metadata, and associated media URLs.</p>
-
-            <h4>Response Fields:</h4>
-            <ul class="field-list">
-                <li><code>transcript</code>: Object containing transcript details
-                    <ul>
-                        <li><code>_id</code>: Unique identifier for the transcript</li>
-                        <li><code>created_at</code>: Timestamp when the transcript was created</li>
-                        <li><code>words</code>: Array of word objects, each containing:
-                            <ul>
-                                <li><code>start</code>: Start time of the word in seconds</li>
-                                <li><code>end</code>: End time of the word in seconds</li>
-                                <li><code>text</code>: The actual word</li>
-                            </ul>
-                        </li>
-                        <li><code>paragraphs</code>: Array of paragraph objects with speaker and timing information</li>
-                        <li><code>status</code>: Status of the transcript (e.g., "completed")</li>
-                        <li><code>storyId</code>: ID of the associated story</li>
-                        <li><code>updated_at</code>: Timestamp when the transcript was last updated</li>
-                    </ul>
-                </li>
-                <li><code>story</code>: Object containing story details
-                    <ul>
-                        <li><code>_id</code>: Unique identifier for the story</li>
-                        <li><code>title</code>: Title of the story</li>
-                        <li><code>author</code>: Information about the story's author/creator</li>
-                        <li><code>record_date</code>: Date when the recording was made</li>
-                        <li><code>duration</code>: Duration of the recording in seconds</li>
-                        <li><code>indexes</code>: Array of index objects containing chapter metadata</li>
-                        <li><code>asyncOperations</code>: Array of processing operations performed on the story</li>
-                        <li>Additional metadata about the recording</li>
-                    </ul>
-                </li>
-                <li><code>videoURL</code>: URL to access the video recording</li>
-                <li><code>participants</code>: Array of participants in the recording</li>
-                <li><code>tags</code>: Array of tags associated with the recording</li>
-            </ul>
-
-            <h4>Example Response (truncated):</h4>
-            <pre><code>{
-    "transcript": {
-        "_id": "abc123def456ghi789",
-        "created_at": "2025-01-27T16:46:48.850Z",
-        "words": [
-            {
-                "start": 1.12,
-                "end": 1.44,
-                "text": "Super"
-            },
-            {
-                "start": 1.44,
-                "end": 1.8,
-                "text": "quickly."
-            },
-            {
-                "start": 1.8,
-                "end": 2.16,
-                "text": "Then"
-            },
-            // Additional words...
-        ],
-        "paragraphs": [
-            {
-                "start": 0,
-                "end": 105.6,
-                "speaker": "SPEAKER_S1"
-            }
-        ],
-        "status": "completed",
-        "storyId": "def456ghi789jkl012",
-        "updated_at": "2025-01-27T16:46:48.850Z"
-    },
-    "story": {
-        "_id": "def456ghi789jkl012",
-        "title": "Example Recording",
-        "record_date": "2025-01-27T16:44:51.289Z",
-        "duration": 107,
-        // Additional story metadata...
-    },
-    "videoURL": "https://example.s3.amazonaws.com/uploads/example-id/transcoded.mp4?token=example",
-    "participants": [],
-    "tags": []
+<pre><code>{
+  "page": 1,
+  "total": 234,
+  "items": [
+    {
+      "_id": "def456ghi789jkl012",
+      "title": "Example Recording",
+      "record_date": "2025-01-27T16:44:51.289Z",
+      "duration": 107,
+      "author": { "id": 12345, "first_name": "John", "last_name": "Doe" },
+      "indexes": [],
+      "asyncOperations": []
+    }
+  ]
 }</code></pre>
-        </div>
 
-        <h3 id="transcript-html">Get Story Transcript HTML</h3>
-        <p>Retrieves the transcript of a specific story in HTML format, suitable for interactive transcripts using the Hyperaudio Lite library.</p>
+<h4 id="transcript-json">Get story transcript JSON</h4>
 
-        <div class="endpoint-url">
-            <span class="http-method">GET</span>
-            <code>https://node.theirstory.io/stories/{storyid}/html</code>
-            <button class="copy-btn" onclick="copyToClipboard('https://node.theirstory.io/stories/{storyid}/html')">
-                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                    <path d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2"></path>
-                    <rect x="8" y="2" width="8" height="4" rx="1" ry="1"></rect>
-                </svg>
-            </button>
-        </div>
+<p>Retrieves a story's transcript in JSON format, including word-level timing and story metadata.</p>
 
-        <h4>Path Parameters:</h4>
-        <ul>
-            <li><code>storyid</code> (required): The unique identifier of the story</li>
-        </ul>
+<div class="endpoint"><span class="method">GET</span>/transcripts/{storyId}</div>
 
-        <div class="response-section">
-            <h4>Response:</h4>
-            <p>The response is an HTML document containing the transcript with timing data attributes that make it compatible with interactive transcript libraries like Hyperaudio Lite.</p>
+<h5>Path parameters</h5>
 
-            <h4>Example Response:</h4>
-            <pre><code>&lt;article&gt;
-    &lt;section&gt;
-        &lt;p&gt;
-            &lt;span data-m="0" data-d="0" class="speaker"&gt;SPEAKER_S1: &lt;/span&gt;
-            &lt;span data-m="1120" data-d="320"&gt;Super &lt;/span&gt;
-            &lt;span data-m="1440" data-d="360"&gt;quickly. &lt;/span&gt;
-            &lt;span data-m="1800" data-d="360"&gt;Then &lt;/span&gt;
-            &lt;span data-m="2240" data-d="240"&gt;this &lt;/span&gt;
-            &lt;span data-m="2480" data-d="200"&gt;is &lt;/span&gt;
-            &lt;span data-m="2680" data-d="200"&gt;the &lt;/span&gt;
-            &lt;span data-m="3040" data-d="280"&gt;bug &lt;/span&gt;
-            &lt;span data-m="3320" data-d="320"&gt;where &lt;/span&gt;
-            ...
-        &lt;/p&gt;
-    &lt;/section&gt;
+<table>
+  <thead>
+    <tr><th>Parameter</th><th>Description</th></tr>
+  </thead>
+  <tbody>
+    <tr><td><code>storyId</code></td><td>The unique identifier of the story.</td></tr>
+  </tbody>
+</table>
+
+<h5>Response fields</h5>
+
+<table>
+  <thead>
+    <tr><th>Field</th><th>Type</th><th>Description</th></tr>
+  </thead>
+  <tbody>
+    <tr><td><code>transcript</code></td><td>object</td><td>Transcript content and metadata; see below.</td></tr>
+    <tr><td><code>story</code></td><td>object</td><td>Story metadata.</td></tr>
+    <tr><td><code>videoURL</code></td><td>string</td><td>Time-limited URL to the video recording.</td></tr>
+    <tr><td><code>participants</code></td><td>array</td><td>Participants in the recording.</td></tr>
+    <tr><td><code>tags</code></td><td>array</td><td>Tags applied to the recording.</td></tr>
+  </tbody>
+</table>
+
+<p><code>transcript</code> contains:</p>
+
+<table>
+  <thead>
+    <tr><th>Field</th><th>Type</th><th>Description</th></tr>
+  </thead>
+  <tbody>
+    <tr><td><code>_id</code></td><td>string</td><td>Transcript identifier.</td></tr>
+    <tr><td><code>status</code></td><td>string</td><td><code>completed</code>, <code>processing</code>, <code>failed</code>.</td></tr>
+    <tr><td><code>storyId</code></td><td>string</td><td>Story this transcript belongs to.</td></tr>
+    <tr><td><code>words</code></td><td>array</td><td>Word-level entries: <code>{ start, end, text }</code> in seconds.</td></tr>
+    <tr><td><code>paragraphs</code></td><td>array</td><td>Paragraph-level entries: <code>{ start, end, speaker }</code>.</td></tr>
+    <tr><td><code>created_at</code></td><td>string</td><td>When the transcript was created.</td></tr>
+    <tr><td><code>updated_at</code></td><td>string</td><td>When the transcript was last updated.</td></tr>
+  </tbody>
+</table>
+
+<blockquote class="warn">
+  <p><strong><code>videoURL</code> is short-lived and signed.</strong> Don't cache or share it. Re-request the transcript to get a fresh URL.</p>
+</blockquote>
+
+<h5>Example response (abbreviated)</h5>
+
+<pre><code>{
+  "transcript": {
+    "_id": "abc123def456ghi789",
+    "status": "completed",
+    "storyId": "def456ghi789jkl012",
+    "words": [
+      { "start": 1.12, "end": 1.44, "text": "Super" },
+      { "start": 1.44, "end": 1.80, "text": "quickly." }
+    ],
+    "paragraphs": [
+      { "start": 0, "end": 105.6, "speaker": "SPEAKER_S1" }
+    ],
+    "created_at": "2025-01-27T16:46:48.850Z",
+    "updated_at": "2025-01-27T16:46:48.850Z"
+  },
+  "story": {
+    "_id": "def456ghi789jkl012",
+    "title": "Example Recording",
+    "record_date": "2025-01-27T16:44:51.289Z",
+    "duration": 107
+  },
+  "videoURL": "https://example.s3.amazonaws.com/uploads/example-id/transcoded.mp4?token=example",
+  "participants": [],
+  "tags": []
+}</code></pre>
+
+<h4 id="transcript-html">Get story transcript HTML</h4>
+
+<p>Retrieves a story's transcript as HTML with timing attributes, suitable for use with <a href="https://github.com/hyperaudio/hyperaudio-lite">Hyperaudio Lite</a> and similar interactive-transcript libraries.</p>
+
+<div class="endpoint"><span class="method">GET</span>/stories/{storyId}/html</div>
+
+<blockquote class="note">
+  <p>Note: this endpoint is under <code>/stories/...</code> while the JSON variant above is under <code>/transcripts/...</code>. This is a historical inconsistency we plan to resolve; both will continue to work.</p>
+</blockquote>
+
+<h5>Response</h5>
+
+<p>An HTML document. Each word is wrapped in a <code>&lt;span&gt;</code> with timing data attributes:</p>
+
+<table>
+  <thead>
+    <tr><th>Attribute</th><th>Description</th></tr>
+  </thead>
+  <tbody>
+    <tr><td><code>data-m</code></td><td>Start time of the word in milliseconds.</td></tr>
+    <tr><td><code>data-d</code></td><td>Duration of the word in milliseconds.</td></tr>
+    <tr><td><code>class="speaker"</code></td><td>Marks a speaker label.</td></tr>
+  </tbody>
+</table>
+
+<h5>Example response</h5>
+
+<pre><code>&lt;article&gt;
+  &lt;section&gt;
+    &lt;p&gt;
+      &lt;span data-m="0" data-d="0" class="speaker"&gt;SPEAKER_S1: &lt;/span&gt;
+      &lt;span data-m="1120" data-d="320"&gt;Super &lt;/span&gt;
+      &lt;span data-m="1440" data-d="360"&gt;quickly. &lt;/span&gt;
+      &lt;span data-m="1800" data-d="360"&gt;Then &lt;/span&gt;
+      ...
+    &lt;/p&gt;
+  &lt;/section&gt;
 &lt;/article&gt;</code></pre>
 
-            <h4>HTML Format Details:</h4>
-            <ul class="field-list">
-                <li><code>data-m</code>: Timestamp in milliseconds for when the word begins</li>
-                <li><code>data-d</code>: Duration of the word in milliseconds</li>
-                <li><code>class="speaker"</code>: Denotes a speaker change in the transcript</li>
-            </ul>
+<h3 id="groups">Groups</h3>
 
-            <h4>Usage with Hyperaudio Lite:</h4>
-            <p>This HTML format is designed to work with libraries like Hyperaudio Lite to create interactive transcripts where:</p>
-            <ul>
-                <li>Clicking on a word jumps the audio/video to that timestamp</li>
-                <li>Words are highlighted as the audio/video plays</li>
-                <li>Searching within the transcript is possible</li>
-                <li>Different speakers can be visually distinguished</li>
-            </ul>
-        </div>
-        </section>
+<blockquote class="note">
+  <p><strong>This endpoint is documented as available but its response shape is not yet finalized.</strong> Contact us if you need to integrate against it; we will update this section once the response is stable.</p>
+</blockquote>
 
-        <div class="endpoint-divider"></div>
+<div class="endpoint"><span class="method">GET</span>/groups</div>
 
-        <section id="groups">
-            <h3>Groups</h3>
-        <p>Retrieves information about groups within an organization.</p>
+<h3 id="publishing">Publishing</h3>
 
-        <div class="endpoint-url">
-            <span class="http-method">GET</span>
-            <code>https://node.theirstory.io/groups</code>
-            <button class="copy-btn" onclick="copyToClipboard('https://node.theirstory.io/groups')">
-                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                    <path d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2"></path>
-                    <rect x="8" y="2" width="8" height="4" rx="1" ry="1"></rect>
-                </svg>
-            </button>
-        </div>
-        </section>
+<p>The publishing endpoints create non-expiring media assets on our Mux-backed CDN, useful when you need stable URLs to embed in external systems.</p>
 
-         <div class="endpoint-divider"></div>
+<h4>Publish</h4>
 
-        <section id="publishing">
-            <h3>Publishing</h3>
-        <p>There are cases where it's convenient to publish (non expiring) media assets. We provide a number of API endpoints allowing the publishing, unpublishing and interrogation of audio and video assets on our Mux.com based CDN.</p>
+<div class="endpoint"><span class="method">POST</span>/stories/{storyId}/publish_media</div>
 
-        <h4>publish</h4>
-        <div class="endpoint-url">
-            <span class="http-method">POST</span>
-            <code>https://node.theirstory.io/stories/{storyId}/publish_media</code>
-            <button class="copy-btn" onclick="copyToClipboard('https://node.theirstory.io/stories/{storyId}/publish_media')">
-                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                    <path d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2"></path>
-                    <rect x="8" y="2" width="8" height="4" rx="1" ry="1"></rect>
-                </svg>
-            </button>
-        </div>
-        
-        <h4>Request Body:</h4>
-        <p>The request should include the type of media required (audio or video).</p>
-<pre><code>
-{
-   "format": "video"
+<h5>Request body</h5>
+
+<pre><code>{ "format": "video" }</code></pre>
+
+<p><code>format</code> accepts <code>"video"</code> or <code>"audio"</code>.</p>
+
+<h5>Response</h5>
+
+<pre><code>{ "url": "https://stream.mux.com/{uid}/highest.mp4" }</code></pre>
+
+<p>For audio:</p>
+
+<pre><code>{ "url": "https://stream.mux.com/{uid}/audio.m4a" }</code></pre>
+
+<blockquote class="note">
+  <p><strong>Assets may take up to a minute to be created.</strong> The URL is returned immediately but may 404 or stream a placeholder until processing completes. There is currently no status endpoint or webhook; if you need to verify availability, poll the returned URL with a <code>HEAD</code> request until it succeeds. We recommend a poll interval of 5&ndash;10 seconds and a total timeout of 2 minutes.</p>
+</blockquote>
+
+<h4>Unpublish</h4>
+
+<div class="endpoint"><span class="method">POST</span>/stories/{storyId}/unpublish_media</div>
+
+<h5>Request body</h5>
+
+<pre><code>{ "format": "video" }</code></pre>
+
+<h5>Response</h5>
+
+<pre><code>{
+  "message": "video deleted",
+  "url": "https://stream.mux.com/{uid}/highest.mp4"
 }</code></pre>
 
-        <div class="response-section">
-            <h4>Response:</h4>
-            <p>The response will return the URL of where the video asset will be created.</p>
+<h4>Example code</h4>
 
-            <h4>Response Fields:</h4>
-            <pre><code>
-"url": "https://stream.mux.com/{uid}/highest.mp4"    
-            </code></pre>
-        </div>
-
-<pre><code>
-{
-   "format": "audio"
-}</code></pre>
-
-        <div class="response-section">
-            <h4>Response:</h4>
-            <p>The response will return the URL of where the audio asset will be created.</p>
-
-            <h4>Response Fields:</h4>
-            <pre><code>
-"url": "https://stream.mux.com/{uid}/audio.m4a"    
-            </code></pre>
-        </div>
-            
-        <p>NOTE: Assets may take up to a minute to be created.</p>
-
-         <h4>unpublish</h4>
-         <div class="endpoint-url">
-            <span class="http-method">POST</span>
-            <code>https://node.theirstory.io/stories/{storyId}/unpublish_media</code>
-            <button class="copy-btn" onclick="copyToClipboard('https://node.theirstory.io/stories/{storyId}/publish_media')">
-                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                    <path d="M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2"></path>
-                    <rect x="8" y="2" width="8" height="4" rx="1" ry="1"></rect>
-                </svg>
-            </button>
-        </div>
-
-        <h4>Request Body:</h4>
-        <p>The request should include the type of media required (audio or video).</p>
-        <pre><code>
-{
-    "format": "video"
-}
-        </code></pre>
-
-        <div class="response-section">
-            <h4>Response:</h4>
-            <p>The response will return a message and the URL of the video asset that is deleted.</p>
-
-            <h4>Response Fields:</h4>
-            <pre><code>
-"message": "video deleted",
-"url": "https://stream.mux.com/{uid}/highest.mp4"    
-            </code></pre>
-        </div>
-
-        <pre><code>
-{
-   "format": "audio"
-}</code></pre>
-
-        <div class="response-section">
-            <h4>Response:</h4>
-            <p>The response will return the URL of where the audio asset asset that is deleted.</p>
-
-            <h4>Response Fields:</h4>
-            <pre><code>
-"message": "audio deleted",
-"url": "https://stream.mux.com/{uid}/audio.m4a"    
-            </code></pre>
-        </div>
-       
-
-        <h4>Example code:</h4>
-        <div class="example-code">
-            <pre><code>
-fetch(`https://node.theirstory.io/stories/${storyId}/publish_media`, {
+<pre><code>const response = await fetch(
+  `https://node.theirstory.io/stories/${storyId}/publish_media`,
+  {
     method: 'POST',
     headers: {
-        'Authorization': token,
-        'Content-Type': 'application/json',
-        'Accept': 'application/json',
+      'Authorization': token,             // raw JWT, no "Bearer" prefix
+      'Content-Type': 'application/json',
+      'Accept': 'application/json'
     },
-    body: JSON.stringify({ format: format })
-})
-.then(response => {
-    if (!response.ok) {
-        throw new Error(`Failed to publish ${format}`);
-    }
-    return response.json();
-}).catch(error => {
-    console.error('Error:', error);
-    modalTitle.textContent = 'Error';
-    modalBody.innerHTML = `
-            Failed to publish ${format}: ${error.message}
-    `;
-})
-        </div>
-            </code></pre>
-        </section>
+    body: JSON.stringify({ format: 'video' })
+  }
+);
 
+if (!response.ok) {
+  throw new Error(`Publish failed: ${response.status}`);
+}
 
-            
-        </section>
-    </section>
+const { url } = await response.json();</code></pre>
 
-    <div class="endpoint-divider"></div>
+<h2 id="error-handling">Error handling</h2>
 
-    <section id="error-handling">
-        <h2>Error Handling</h2>
-        <p>The API uses standard HTTP status codes to indicate success or failure of requests. Error responses include detailed information about the error and possible solutions.</p>
-        
-        <h4>Common Error Codes:</h4>
-        <ul>
-            <li><strong>400</strong> - Bad Request: The request was malformed or contained invalid parameters</li>
-            <li><strong>401</strong> - Unauthorized: Authentication is required or has failed</li>
-            <li><strong>403</strong> - Forbidden: The authenticated user doesn't have permission for the requested operation</li>
-            <li><strong>404</strong> - Not Found: The requested resource does not exist</li>
-            <li><strong>429</strong> - Too Many Requests: Rate limit has been exceeded</li>
-            <li><strong>500</strong> - Internal Server Error: An unexpected error occurred on the server</li>
-        </ul>
-    </section>
+<p>The API uses standard HTTP status codes. Error responses are JSON objects of the shape:</p>
 
-    <div class="endpoint-divider"></div>
+<pre><code>{
+  "error": "short_error_code",
+  "message": "Human-readable description of what went wrong."
+}</code></pre>
 
-    <section id="security">
-        <h2>Security Considerations</h2>
-        <p>When working with the TheirStory API, keep the following security considerations in mind:</p>
-        
-        <ul>
-            <li>Store API tokens securely and never expose them in client-side code</li>
-            <li>Implement proper token refresh mechanisms to maintain secure sessions</li>
-            <li>Use HTTPS for all API requests to ensure data is encrypted in transit</li>
-            <li>Follow the principle of least privilege when requesting access to user data</li>
-            <li>Implement proper error handling to avoid leaking sensitive information</li>
-        </ul>
-    </section>
+<table>
+  <thead>
+    <tr><th>Status</th><th>Meaning</th><th>Common causes</th></tr>
+  </thead>
+  <tbody>
+    <tr><td>400</td><td>Bad Request</td><td>Malformed JSON, missing required parameters.</td></tr>
+    <tr><td>401</td><td>Unauthorized</td><td>Missing, expired, or invalid token.</td></tr>
+    <tr><td>403</td><td>Forbidden</td><td>Valid token but insufficient permissions. <strong>Also returned if the <code>Authorization</code> header includes <code>Bearer </code> &mdash; see <a href="#auth-header">Authorization header format</a>.</strong></td></tr>
+    <tr><td>404</td><td>Not Found</td><td>Resource does not exist or the caller cannot see it.</td></tr>
+    <tr><td>429</td><td>Too Many Requests</td><td>Rate limit exceeded. See <a href="#rate-limits">Rate limits</a>.</td></tr>
+    <tr><td>500</td><td>Internal Server Error</td><td>Unexpected error. Retry with backoff and contact support if it persists.</td></tr>
+  </tbody>
+</table>
+
+<h2 id="rate-limits">Rate limits</h2>
+
+<p>The API enforces per-token rate limits. Exceeding the limit returns <code>429 Too Many Requests</code>. We do not currently publish specific limits; design your integration to back off on <code>429</code> and retry after a delay of at least 1 second, doubling on repeated failures. Contact us if your integration needs sustained high throughput.</p>
+
+<h2 id="security">Security considerations</h2>
+
+<ul>
+  <li><strong>Authorization header format is non-standard on this API.</strong> See <a href="#auth-header">Authorization header format</a>. This is the most common cause of <code>403</code> errors for new integrators.</li>
+  <li><strong>Don't put tokens where untrusted JavaScript can read them.</strong> Any script on a page where you've stored a token in <code>localStorage</code> or <code>sessionStorage</code> can read and exfiltrate it. For browser integrations, prefer the BFF pattern (your server holds the TheirStory token; your browser talks to your server) and treat <code>localStorage</code> storage as an explicit convenience tradeoff. See <a href="#token-storage">Token storage in browser clients</a>.</li>
+  <li><strong>Use HTTPS for all requests.</strong> The API only accepts HTTPS connections.</li>
+  <li><strong>Invitation codes are credentials.</strong> <code>view_only_code</code>, <code>member_code</code>, and <code>project_manager_code</code> grant project access; don't leak them in logs, analytics, or public URLs.</li>
+  <li><strong>Signed asset URLs expire.</strong> <code>videoURL</code> and similar signed URLs in responses are short-lived. Don't cache them and don't share them; re-fetch the parent resource to get a fresh URL.</li>
+  <li><strong>Apply least privilege.</strong> Use the role with the minimum permissions needed for your integration.</li>
+  <li><strong>Handle errors carefully.</strong> Don't surface raw API error messages to end users; log them server-side and show generic messages to users.</li>
+</ul>
+
+<h2 id="versioning">Versioning</h2>
+
+<p>The API URL is not versioned. Responses include an <code>api_version</code> field that reflects the server's deployed version (a semantic version string). Breaking changes are communicated through release notes; subscribe to repository updates or contact support to be notified.</p>
+
+<p>Backwards-compatible changes (new fields, new endpoints) may be added without notice. Treat your response parsing accordingly &mdash; ignore fields you don't recognize rather than failing.</p>
+
+<h2 id="support">Support</h2>
+
+<ul>
+  <li>Issues with this documentation: open an issue at <a href="https://github.com/theirstory/theirstory-api/issues">https://github.com/theirstory/theirstory-api/issues</a>.</li>
+  <li>API access requests and integration questions: contact TheirStory support.</li>
+  <li>Embedded iframe examples: <a href="iframe-examples.html">iframe-examples.html</a>.</li>
+</ul>
+
+</div>
 </body>
 </html>


### PR DESCRIPTION
docs: rewrite API guide for clarity, consistency, and integrator pitfalls

Replaces index.html with a restructured guide that addresses long-standing gaps and contradictions in the public API documentation. No server behavior is changing.

Highlights:

- Document the non-standard Authorization header. The API expects the raw JWT with no "Bearer" prefix, which is the most common cause of 403s for new integrators using Postman, curl examples, or standard client libraries. The format is called out at the top of Authentication, in the 403 row of the error table, and in Security Considerations, with explicit Postman and curl guidance.

- Reframe browser token storage. The previous "store securely / never expose in client-side code" guidance contradicted the localStorage in the Sign In example. New "Token storage in browser clients" section presents the three options (in-memory, sessionStorage, localStorage) as a tradeoff table, recommends the backend-for-frontend pattern for production browser apps, and flags that HttpOnly cookie support is on the roadmap. The sample code still uses localStorage but with an explicit caveat rather than as a recommendation.

- Add missing essentials: token lifetime and refresh (call /signin again, no refresh endpoint), pagination behavior (only /stories paginates), rate-limit guidance, error response body shape, and a versioning policy (unversioned URL, api_version field, forward-compatible parsing expected).

- Document visitorId. Previously listed as required with no explanation; now documented as the value bound to the JWT's visitor-id claim.

- Per-endpoint field tables. Every endpoint now has typed field tables (string / number / boolean / object / array) rather than loose bullet lists, with internal fields (_id, __v) called out as read-only storage internals.

- Acknowledge known inconsistencies: export_allowed vs aviary_export_allowed (both documented, with guidance on which to prefer); mixed snake_case and camelCase (acknowledged, normalization on backlog); /transcripts/{storyId} vs /stories/{storyId}/html base-path divergence (noted in-place). Path parameter casing is normalized to storyId throughout.

- Stories list endpoint now has a documented response shape with a pointer to the transcript JSON response as the canonical story object reference.

- Publishing endpoints now document the up-to-a-minute asset creation delay with a concrete HEAD-poll recommendation (5-10s interval, 2min timeout) instead of leaving readers to discover this themselves.

- Groups endpoint is marked as documentation-pending rather than left as a silent stub.

- Invitation codes (view_only_code, member_code, project_manager_code) flagged as credentials with a sensitivity callout. videoURL flagged as short-lived and signed.

- New Support section with a path for filing doc issues and a link to the iframe examples page.

- Visual style: GitHub Pages-flavored layout with light/dark mode, table of contents, callout styles for notes/warnings, and method badges on endpoint URLs. No external dependencies.

The cookie-based session auth work referenced under Token Storage is tracked separately and is not part of this commit.